### PR TITLE
Fixed typo in example

### DIFF
--- a/mandrill.go
+++ b/mandrill.go
@@ -20,7 +20,7 @@
 //     msg.Subject = "subject"
 //     msg.FromEmail = "email@domain.com"
 //     msg.FromName = "your name"
-//     res, err := msg.Send(fase)
+//     res, err := msg.Send(false)
 //
 // It's even easier to send a message using a template:
 //

--- a/mandrill.go
+++ b/mandrill.go
@@ -150,6 +150,8 @@ type Message struct {
 	Attachments []*Attachment `json:"attachments,omitempty"`
 	// optional extra headers to add to the message (most headers are allowed)
 	Headers map[string]string `json:"headers,omitempty"`
+	// merge language to be used (can be mailchimp or handlebars)
+	MergeLanguage string `json:"merge_language,omitempty"`
 	// TODO implement other fields
 }
 


### PR DESCRIPTION
There was a typo in the msg.Send() of the example. A var fase is passed to the function, changed it to false.